### PR TITLE
Use global fetch

### DIFF
--- a/src/authenticationHelper.ts
+++ b/src/authenticationHelper.ts
@@ -54,7 +54,7 @@ export class AuthenticationHelper {
       open_timeout: 5000
     };
 
-    const response = await AuthenticationHelper.fetch(authUri.toString(), options);
+    const response = await fetch(authUri.toString(), options);
     const body = await response.json();
     if (response.status !== 200) {
       throw {
@@ -106,7 +106,7 @@ export class AuthenticationHelper {
 
     const authUri = new URI(user.server).path('/auth');
 
-    const response = await AuthenticationHelper.fetch(authUri.toString(), options);
+    const response = await fetch(authUri.toString(), options);
     const body = await response.json();
 
     if (response.status !== 200) {
@@ -139,12 +139,12 @@ export class AuthenticationHelper {
       body: JSON.stringify({
         token: user.token
       }),
-      headers: { authorization: user.token, ...AuthenticationHelper.postHeaders},
+      headers: { authorization: user.token, ...AuthenticationHelper.postHeaders },
       timeout: 5000.0
     };
 
     const authUri = new URI(user.server).path('/auth/revoke');
-    const response = await AuthenticationHelper.fetch(authUri.toString(), options);
+    const response = await fetch(authUri.toString(), options);
 
     if (response.status !== 200) {
       const body = await response.json();
@@ -157,19 +157,8 @@ export class AuthenticationHelper {
     }
   }
 
-  public static getFetch() {
-    return this.fetch;
-  }
-
-  private static requireMethod = require;
-  private static fetch = typeof fetch === 'undefined' ? AuthenticationHelper.nodeRequire('node-fetch') : fetch;
-
   private static postHeaders = {
     'content-type': 'application/json;charset=utf-8',
     'accept': 'application/json'
   };
-
-  private static nodeRequire(module) {
-    return AuthenticationHelper.requireMethod(module);
-  }
 }

--- a/tests/helper.spec.ts
+++ b/tests/helper.spec.ts
@@ -29,6 +29,9 @@ import { v4 } from 'uuid';
 import { GraphQLError } from 'graphql/error/GraphQLError';
 
 describe('RealmGraphQL', async function() {
+  // @ts-ignore
+  global.fetch = fetch;
+
   const userId = v4();
 
   let realmUser: Realm.Sync.User;


### PR DESCRIPTION
Due to `AuthenticationHelper` being used in both `GraphQLConfig` and `User`, `fetch` as an option as in [`apollo-link-http`](https://sourcegraph.com/github.com/apollographql/apollo-link/-/blob/packages/apollo-link-http/src/httpLink.ts#L49:8) is not easily done. Options are: setting in userland with #13 on `AuthenticationHelper`; setting in userland on `GraphQLConfig` with `GraphQLConfig.fetch` in place of `AuthenticationHelper.fetch`. Both would require an additional line before `User.authenticate` is called (reason why `fetch` cannot be passed as an option to `GraphQLConfig`).

In both cases it seems it would be nontrivial to check for `fetch` to avoid incurring in a `ReferenceError` (see `apollo-link-http`’s [`checkFetcher`](https://sourcegraph.com/github.com/apollographql/apollo-link/-/blob/packages/apollo-link-http/src/httpLink.ts#L44)) as there are two points of entry (`User.authenticate` and `GraphQLConfig.create`); unless of course `fetch` is passed to `User.authenticate` (it didn’t seem to fit).

Fixes #10, but it’d be better to follow `apollo-link-http`’s example.

_(devnote: It seems `ros` does not support Node 9, and there’s currently an issue with `@types/colors` (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/9844) that’s bypassed by monkey patching the declaration)._